### PR TITLE
fix: make guild_id optional in thread interface

### DIFF
--- a/src/interfaces/Thread.interface.ts
+++ b/src/interfaces/Thread.interface.ts
@@ -34,7 +34,7 @@ export interface ForumTag {
 export interface BaseThread {
   id: Snowflake;
   type: 10 | 11 | 12;
-  guild_id: Snowflake;
+  guild_id?: Snowflake;
   parent_id: Snowflake;
   owner_id: Snowflake;
   name: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the thread data structure to make the guild ID optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->